### PR TITLE
feat: skip NPM publish on forked repositories in prerelease and release workflows

### DIFF
--- a/.github/workflows/prerelease-reusable.yml
+++ b/.github/workflows/prerelease-reusable.yml
@@ -104,6 +104,8 @@ jobs:
         run: npm pack
 
       - name: "Publish to npm (dist-tag: next)"
+        # Skip NPM publish on forked repositories (no NPM_TOKEN available)
+        if: github.repository == 'winccoa-tools-pack/npm-winccoa-core'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --tag next --access public --ignore-scripts

--- a/.github/workflows/release-reusable.yml
+++ b/.github/workflows/release-reusable.yml
@@ -110,6 +110,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Publish to npm (dist-tag: latest)"
+        # Skip NPM publish on forked repositories (no NPM_TOKEN available)
+        if: github.repository == 'winccoa-tools-pack/npm-winccoa-core'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         shell: bash


### PR DESCRIPTION
Do not publish NPM packages in case of forked repository.