### PR TITLE
fix(release): ignore broken pipe error when listing tarball contents

### DIFF
--- a/.github/workflows/release-reusable.yml
+++ b/.github/workflows/release-reusable.yml
@@ -136,7 +136,7 @@ jobs:
 
           # Verify the new tarball
           echo "📋 Contents of new tarball:"
-          tar -tzf "dist/$CLEAN_NAME" | head -20
+          tar -tzf "dist/$CLEAN_NAME" | head -20 || true
 
           # Cleanup staging
           rm -rf staging


### PR DESCRIPTION
## Summary
Fixes the release workflow failure caused by 'tar: stdout: write error' when listing tarball contents.

## Problem
The \	ar -tzf | head -20\ command failed with exit code 2 (SIGPIPE) when tar wrote more than 20 lines and head closed the pipe.

## Solution
Added \|| true\ to ignore this non-critical error since listing the contents is just for logging/verification purposes.

## Testing
Re-run the release workflow after merging.