### PR TITLE
fix: merge duplicate config sections instead of overwriting

### DIFF
--- a/src/types/project/ProjEnvProjectConfig.ts
+++ b/src/types/project/ProjEnvProjectConfig.ts
@@ -219,7 +219,11 @@ export class ProjEnvProjectConfig {
 
             if (trimmedLine.startsWith('[') && trimmedLine.endsWith(']')) {
                 currentSection = trimmedLine.slice(1, -1);
-                sections[currentSection] = Object.create(null);
+                // Reuse existing section object to merge keys from duplicate sections
+                // (WinCC OA config files legitimately contain multiple sections with the same name)
+                if (!sections[currentSection]) {
+                    sections[currentSection] = Object.create(null);
+                }
             } else if (currentSection && trimmedLine.includes('=')) {
                 const [key, ...valueParts] = trimmedLine.split('=');
                 const value = valueParts.join('=').trim().replace(/['"]/g, '');

--- a/test/unit/ProjEnvProjectConfig.test.ts
+++ b/test/unit/ProjEnvProjectConfig.test.ts
@@ -77,4 +77,27 @@ describe('ProjEnvProjectConfig', () => {
     const content = fs.readFileSync(cfgPath, 'utf-8');
     assert.doesNotMatch(content, /rem =/);
   });
+
+  it('merges keys from duplicate sections', () => {
+    const content = [
+      '[general]',
+      'proj_version = "3.20"',
+      'pvss_path = "/opt/WinCC_OA/3.20"',
+      '',
+      '[event]',
+      'fwdDpType = "SubSystem.Actual.State_1"',
+      '',
+      '[general]',
+      'ctrlMaxPendings = 2000',
+      '',
+    ].join('\n');
+    writeFile(cfgPath, content);
+
+    // proj_version from first [general] must survive
+    assert.equal(cfg.getEntryValue('proj_version', 'general'), '3.20');
+    // key from second [general] must also be present
+    assert.equal(cfg.getEntryValue('ctrlMaxPendings', 'general'), '2000');
+    // key from first [general] also preserved
+    assert.equal(cfg.getEntryValue('pvss_path', 'general'), '/opt/WinCC_OA/3.20');
+  });
 });


### PR DESCRIPTION
## Summary                                               

  - Config parser (`ProjEnvProjectConfig.parseConfigSections()`) was overwriting section data when
  encountering duplicate section headers
  - WinCC OA config files legitimately may contain multiple [general], [event], etc. sections — this is
  valid and found in production configs
  - Keys from earlier sections (like proj_version) were silently lost, causing project version
  detection to fail

 ## Problem

  Projects with configs like this would fail to load:
```
  [general]
  proj_version = "3.20"
  pvss_path = "/opt/WinCC_OA/3.20"

  [event]
  fwdDpType = "SubSystem.Actual.State_1"

  [general]
  ctrlMaxPendings = 2000
```

  The second [general] created a fresh empty object, discarding proj_version and pvss_path. This
  caused:

  `ERROR: Unable to determine project version for project <project>`

  ## Fix

  One-line change: only create a new section object if one doesn't already exist. Duplicate sections
   now merge their keys into a single object. The existing duplicate-key handling (converting to
  arrays) already covers the case where the same key appears in both sections.

 ## Test plan

  - Added unit test: config with two [general] sections — verifies keys from both are accessible
  - All existing tests pass

