### PR TITLE
fix: skip PMON log/warning lines in manager list parser

### DIFF
--- a/src/types/components/implementations/PmonComponent.ts
+++ b/src/types/components/implementations/PmonComponent.ts
@@ -615,7 +615,8 @@ once 30 3 1 -m gedi -n -num 5` to get the properties. It shall be mu more faster
             if (parts.length < 1) continue;
 
             if (parts.length < 6) {
-                throw new Error(`The line '${line}' has incorrect format`);
+                // Skip PMON log/warning lines that appear in stdout output
+                continue;
             }
 
             const name = parts[0];

--- a/test/unit/PmonComponent.parseManagerList.test.ts
+++ b/test/unit/PmonComponent.parseManagerList.test.ts
@@ -1,0 +1,54 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { PmonComponent } from '../../src/types/components/implementations/PmonComponent';
+
+// Expose private parseManagerList for testing
+class TestablePmonComponent extends PmonComponent {
+    public testParseManagerList(output: string) {
+        return (this as any).parseManagerList(output);
+    }
+}
+
+describe('PmonComponent.parseManagerList', () => {
+    const pmon = new TestablePmonComponent();
+
+    it('parses valid manager lines', () => {
+        const output = [
+            'LIST:3',
+            'WCCILpmon;2;30;3;1;',
+            'WCCILdata;2;30;3;1;',
+            'WCCILctrl;2;30;3;1;-num 1 -f main.ctl',
+        ].join('\n');
+
+        const result = pmon.testParseManagerList(output);
+        assert.equal(result.length, 3);
+        assert.equal(result[0].component, 'WCCILpmon');
+        assert.equal(result[2].component, 'WCCILctrl');
+        assert.equal(result[2].startOptions, '-num 1 -f main.ctl');
+    });
+
+    it('skips PMON warning lines mixed into output', () => {
+        const output = [
+            'LIST:2',
+            'WCCILpmon;2;30;3;1;',
+            'WCCILpmon    (1), 2026.03.05 09:32:16.072, PARAM,WARNING,    54, Unexpected state, Resources, readSection, illegal value for useCMContainerSerialNumber, ignored',
+            'WCCILdata;2;30;3;1;',
+        ].join('\n');
+
+        const result = pmon.testParseManagerList(output);
+        assert.equal(result.length, 2);
+        assert.equal(result[0].component, 'WCCILpmon');
+        assert.equal(result[1].component, 'WCCILdata');
+    });
+
+    it('returns empty array for empty output', () => {
+        const result = pmon.testParseManagerList('');
+        assert.deepEqual(result, []);
+    });
+
+    it('returns empty array for output with only log lines', () => {
+        const output = 'WCCILpmon    (1), 2026.03.05 09:32:16.072, PARAM,WARNING, 54, some warning';
+        const result = pmon.testParseManagerList(output);
+        assert.deepEqual(result, []);
+    });
+});


### PR DESCRIPTION
## Issue

When loading the manager list, the extension calls `WCCILpmon` with `-log +stdout`, which means PMON warning messages end up mixed into the same output as the actual manager data. Lines like this show up:

```
WCCILpmon    (1), 2026.03.05 09:32:16.072, PARAM,WARNING, 54, Unexpected state, Resources, readSection, illegal value for useCMContainerSerialNumber, ignored
```

The parser (`parseManagerList`) expects every line to be a semicolon-delimited manager entry with at least 6 fields. When it hits one of these warning lines, it throws an error and the entire Manager tree view fails to load.

## Fix

Instead of throwing on lines that don't have the expected format, we just skip them. Valid manager entries always have 6+ semicolon-separated fields, so any line with fewer parts is clearly not a manager entry — it's a log/warning message that leaked into stdout.

One-line change: `throw new Error(...)` becomes `continue`.

## Test

Added a new test file (`PmonComponent.parseManagerList.test.ts`) covering:
- Normal manager list parsing still works
- PMON warning lines mixed into output are silently skipped
- Empty output returns an empty array
- Output containing only log lines returns an empty array
