### PR TITLE
docs: fix spelling errors, broken links, and CONTRIBUTING.md template text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for contributing to this template.
+Thank you for contributing to this library.
 
 Steps:
 
@@ -8,7 +8,7 @@ Steps:
 - Install and build: `npm install` then `npm run build`
 - Run tests (if any): `npm test`
 - Ensure TypeScript compiles: `npm run build`
-- Commit with clear messages and open a Pull Request against `main`.
+- Commit with clear messages and open a Pull Request against `develop`.
 
 Code style:
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ npm run build
 # Run all tests
 npm test
 
-# Run only unit tests. Without WinCC OA instalation
+# Run only unit tests. Without WinCC OA installation
 npm run test:unit
 
 # Run only integration tests. WinCC OA must be installed.
@@ -180,14 +180,14 @@ This project uses [Git Flow](https://www.atlassian.com/git/tutorials/comparing-w
 - **`release/*`** - Release preparation
 - **`hotfix/*`** - Emergency fixes for production
 
-For detailed workflow information, see [docs/GITFLOW_WORKFLOW.md](docs/GITFLOW_WORKFLOW.md).
+For detailed workflow information, see [docs/automation/GITFLOW_WORKFLOW.md](docs/automation/GITFLOW_WORKFLOW.md).
 
 ## 📖 Documentation
 
 - [Source Code Overview](src/README.md) - Detailed module documentation
 - [Changelog](CHANGELOG.md) - Version history and updates
 - [Contributing Guide](CONTRIBUTING.md) - How to contribute
-- [Development Docs](docs/dev/README.md) - Development guidelines
+- [Development Vision](docs/dev/VISION.md) - Development guidelines
 
 ## 🔧 Configuration
 

--- a/docs/automation/CI-INTEGRATION.md
+++ b/docs/automation/CI-INTEGRATION.md
@@ -28,7 +28,7 @@ Workflow: `.github/workflows/ci-cd.yml` (job: `Integration Tests - WinCC OA`)
 - What it does:
   - pulls a WinCC OA Docker image
   - runs the repo inside the container
-  - executes `npm run ci:integration` (which runs `npm ci`, `npm run compile`, and `npm run test:integrationt`)
+  - executes `npm run ci:integration` (which runs `npm ci`, `npm run compile`, and `npm run test:integration`)
 
 By default, the integration job is a no-op unless an image is configured.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@winccoa-tools-pack/npm-winccoa-core",
   "version": "0.2.6",
+  "description": "Core utilities and type definitions for WinCC OA development",
   "author": "winccoa-tools-pack",
   "license": "MIT",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
## Summary
- Fix spelling error "instalation" ? "installation" in README
- Fix two broken documentation links in README (GITFLOW path, dev docs path)
- Fix typo "integrationt" ? "integration" in CI docs
- Update CONTRIBUTING.md: "template" ? "library", target `develop` branch

## Changes
- `README.md` ? spelling fix and 2 broken link corrections
- `docs/automation/CI-INTEGRATION.md` ? command typo fix
- `CONTRIBUTING.md` ? correct noun and branch target

## Related
- Part of documentation review tracked in winccoa-tools-pack/.github
