### PR TITLE
docs: add package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@winccoa-tools-pack/npm-winccoa-core",
   "version": "0.2.6",
+  "description": "Core utilities and type definitions for WinCC OA development (process control, paths, logs, and shared helpers)",
   "author": "winccoa-tools-pack",
   "license": "MIT",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
Add missing package.json description. Related: winccoa-tools-pack/.github#69