### PR TITLE
ci: use org reusable Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,9 +9,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    # Temporary: points to the reusable workflow PR branch for validation.
-    # After winccoa-tools-pack/.github#85 is merged, switch back to @main.
-    uses: winccoa-tools-pack/.github/.github/workflows/reusable-dependabot-auto-merge.yml@feature/reusable-dependabot-auto-merge
+    uses: winccoa-tools-pack/.github/.github/workflows/reusable-dependabot-auto-merge.yml@main
     with:
       pr_url: ${{ github.event.pull_request.html_url }}
       merge_method: squash

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,26 +1,16 @@
-# Auto-enable squash merge for Dependabot PRs
-# GitHub will automatically merge once all required checks pass
 name: Dependabot Auto-merge
 
-on: pull_request
-
-permissions:
-  contents: write
-  pull-requests: write
+on:
+  pull_request:
 
 jobs:
-  auto-merge:
-    runs-on: ubuntu-latest
+  dependabot-auto-merge:
     if: github.actor == 'dependabot[bot]'
-    steps:
-      - name: Update branch if behind
-        run: gh pr update-branch --rebase "$PR_URL" || true
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: winccoa-tools-pack/.github/.github/workflows/reusable-dependabot-auto-merge.yml@main
+    with:
+      pr_url: ${{ github.event.pull_request.html_url }}
+      merge_method: squash
+      update_branch: true

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,7 +9,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: winccoa-tools-pack/.github/.github/workflows/reusable-dependabot-auto-merge.yml@main
+    # Temporary: points to the reusable workflow PR branch for validation.
+    # After winccoa-tools-pack/.github#85 is merged, switch back to @main.
+    uses: winccoa-tools-pack/.github/.github/workflows/reusable-dependabot-auto-merge.yml@feature/reusable-dependabot-auto-merge
     with:
       pr_url: ${{ github.event.pull_request.html_url }}
       merge_method: squash


### PR DESCRIPTION
Switch Dependabot auto-merge workflow to org reusable workflows.

What this does:
- On Dependabot PR events: update branch (best-effort) + enable auto-merge (squash).
- On every push to develop (no matter who merged): refresh ALL open Dependabot PRs targeting develop (update/rebase best-effort + enable auto-merge).

Requires:
- winccoa-tools-pack/.github#86 (reusable Dependabot refresh workflow)