### PR TITLE
ci: refresh Dependabot PRs on develop updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,12 +23,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    # Temporary: points to the reusable workflow PR branch for validation.
-    # After winccoa-tools-pack/.github#86 is merged, switch to @main.
-    uses: winccoa-tools-pack/.github/.github/workflows/reusable-dependabot-refresh.yml@feature/reusable-dependabot-refresh
+    uses: winccoa-tools-pack/.github/.github/workflows/reusable-dependabot-refresh.yml@main
     with:
       base_branch: develop
       merge_method: squash
       update_branch: true
       enable_auto_merge: true
-      update_branch: true

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,10 +2,13 @@ name: Dependabot Auto-merge
 
 on:
   pull_request:
+  push:
+    branches:
+      - develop
 
 jobs:
   dependabot-auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
     permissions:
       contents: write
       pull-requests: write
@@ -13,4 +16,19 @@ jobs:
     with:
       pr_url: ${{ github.event.pull_request.html_url }}
       merge_method: squash
+      update_branch: true
+
+  dependabot-refresh:
+    if: github.event_name == 'push' && github.ref_name == 'develop'
+    permissions:
+      contents: write
+      pull-requests: write
+    # Temporary: points to the reusable workflow PR branch for validation.
+    # After winccoa-tools-pack/.github#86 is merged, switch to @main.
+    uses: winccoa-tools-pack/.github/.github/workflows/reusable-dependabot-refresh.yml@feature/reusable-dependabot-refresh
+    with:
+      base_branch: develop
+      merge_method: squash
+      update_branch: true
+      enable_auto_merge: true
       update_branch: true


### PR DESCRIPTION
Problem: Dependabot PR branches become behind when ANY PR is merged into develop, but pull_request-only workflows do not run.

Solution:
- On Dependabot PR events: update branch (best-effort) + enable auto-merge (squash).
- On every push to develop (independent of author): refresh ALL open Dependabot PRs targeting develop (update/rebase best-effort + enable auto-merge).