### PR TITLE
ci: create release PR after Dependabot merges

### DIFF
--- a/.github/workflows/dependabot-release-pr.yml
+++ b/.github/workflows/dependabot-release-pr.yml
@@ -1,0 +1,18 @@
+name: Dependabot (create release PR)
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  create-release-pr:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: winccoa-tools-pack/.github/.github/workflows/reusable-dependabot-release-pr.yml@main
+    secrets: inherit
+    with:
+      base_branch: develop
+      target_branch: main
+      enable_auto_merge: false


### PR DESCRIPTION
Adds a workflow that runs on pushes to develop and calls the org reusable workflow to open a release PR into main (patch bump +0.0.1) when the push came from a Dependabot PR.