### PR TITLE
ci: use PAT for Dependabot updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,6 +13,7 @@ jobs:
       contents: write
       pull-requests: write
     uses: winccoa-tools-pack/.github/.github/workflows/reusable-dependabot-auto-merge.yml@main
+    secrets: inherit
     with:
       pr_url: ${{ github.event.pull_request.html_url }}
       approve_pr: true
@@ -25,6 +26,7 @@ jobs:
       contents: write
       pull-requests: write
     uses: winccoa-tools-pack/.github/.github/workflows/reusable-dependabot-refresh.yml@main
+    secrets: inherit
     with:
       base_branch: develop
       merge_method: squash


### PR DESCRIPTION
Wire REPO_ADMIN_TOKEN through by using secrets: inherit for the reusable Dependabot workflows. Prevents required checks from being skipped after automated branch updates.