### PR TITLE
ci: add release-please (PR-only)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,24 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release Please
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
+          release-type: node
+          target-branch: main
+          skip-github-release: true


### PR DESCRIPTION
Adds a minimal Release Please workflow for main.

- Uses org.REPO_ADMIN_TOKEN (fallback to github.token) so the PR triggers normal CI checks.
- skip-github-release: true so GitHub Release + npm publish remain owned by the existing Release workflow.