### PR TITLE
ci: run release-please on develop

### DIFF
--- a/.github/workflows/gitflow-validation.yml
+++ b/.github/workflows/gitflow-validation.yml
@@ -39,6 +39,9 @@ jobs:
               { type: 'main', prefixes: ['main'], expectedBase: 'develop' },
             // fork develop into base develop
               { type: 'fork', prefixes: ['develop'], expectedBase: 'develop' },
+              // Release Please action uses a fixed branch name pattern (not configurable).
+              // Allow it to open release PRs into develop.
+              { type: 'release-please', prefixes: ['release-please--branches--'], expectedBase: 'develop' },
               { type: 'feature', prefixes: ['feature/'], expectedBase: 'develop' },
               { type: 'bugfix',  prefixes: ['bugfix/'],  expectedBase: 'develop' },
               { type: 'chore',   prefixes: ['chore/'],   expectedBase: 'develop', botOnly: true },

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,27 +22,3 @@ jobs:
           release-type: node
           target-branch: develop
           skip-github-release: true
-name: release-please
-
-on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
-
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-
-jobs:
-  release-please:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Release Please
-        uses: googleapis/release-please-action@v4
-        with:
-          token: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
-          release-type: node
-          target-branch: main
-          skip-github-release: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,48 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release Please
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
+          release-type: node
+          target-branch: develop
+          skip-github-release: true
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release Please
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.REPO_ADMIN_TOKEN != '' && secrets.REPO_ADMIN_TOKEN || github.token }}
+          release-type: node
+          target-branch: main
+          skip-github-release: true


### PR DESCRIPTION
Switch Release Please to run on pushes to develop and manage a Release PR against develop (earlier in the flow).

Also updates GitFlow validation to allow Release Please's fixed PR branch naming: elease-please--branches--* (expected base: develop).

Notes:
- Uses REPO_ADMIN_TOKEN (fallback github.token) so Release Please PRs trigger normal CI checks.
- skip-github-release: true so we don't create GitHub Releases from Release Please.