### PR TITLE
fix(ci): avoid create-release-branch concurrency deadlock

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -41,10 +41,6 @@ on:
         default: false
         type: boolean
 
-concurrency:
-  group: create-release-branch-${{ github.repository }}-${{ inputs.version }}
-  cancel-in-progress: false
-
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
Fixes Actions concurrency deadlock when running "Create Release Branch + PR".

Root cause:
- Both the thin caller workflow and the called reusable workflow define the same concurrency group.
- GitHub detects a deadlock between the top-level workflow and the reusable job and cancels.

Fix:
- Remove `concurrency:` from the caller wrapper. The reusable workflow keeps concurrency.
