### PR TITLE
fix(ci): allow issues permission for dependabot labeling

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     uses: winccoa-tools-pack/.github/.github/workflows/reusable-dependabot-auto-merge.yml@main
     secrets: inherit
     with:
@@ -25,6 +26,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     uses: winccoa-tools-pack/.github/.github/workflows/reusable-dependabot-refresh.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
Fix workflow validation error:

The called reusable Dependabot workflows add labels, which requires `issues: write`.
GitHub rejects the caller workflow if it doesn''t grant that permission.

This adds `issues: write` to both jobs in dependabot-auto-merge.yml.
