### PR TITLE
fix(ci): allow issues permission for dependabot release PR

### DIFF
--- a/.github/workflows/dependabot-release-pr.yml
+++ b/.github/workflows/dependabot-release-pr.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     uses: winccoa-tools-pack/.github/.github/workflows/reusable-dependabot-release-pr.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
Fix workflow validation error for dependabot-release-pr.yml.

The called reusable workflow creates PR labels (via create-release-branch), which requires `issues: write`.
This adds `issues: write` to the caller job permissions.
