### PR TITLE
chore(ci): use org reusable rebase-open-prs

### DIFF
--- a/.github/workflows/rebase-open-prs.yml
+++ b/.github/workflows/rebase-open-prs.yml
@@ -1,0 +1,15 @@
+name: Rebase open PRs
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  rebase-prs:
+    # Requires GH_TOKEN_PAT secret (PAT) in this repo or org
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: winccoa-tools-pack/.github/.github/workflows/reusable-rebase-open-prs.yml@main
+    secrets: inherit


### PR DESCRIPTION
Add rebase-open-prs automation using the org reusable workflow.

- Triggers on push to develop
- Calls winccoa-tools-pack/.github reusable-rebase-open-prs

Requires secret:
- GH_TOKEN_PAT (PAT with repo write; may need workflow permission if rebasing PRs that touch workflows)
